### PR TITLE
Remove remaining reference to @latest tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ jobs:
     name: Create pull request attachments on Asana tasks
     steps:
       - name: Create pull request attachments
-        uses: Asana/create-app-attachment-github-action@latest
+        uses: Asana/create-app-attachment-github-action@v1.3
         id: postAttachment
         with:
           asana-secret: ${{ secrets.ASANA_SECRET }}


### PR DESCRIPTION
[This tag](https://github.com/Asana/create-app-attachment-github-action/tags) is quite outdated (circa 2021), and is not actually pulling the latest version. Since the README already references v1.3 in other places, it makes sense to update to use this tag here as well.